### PR TITLE
[FE] feat: 검색 결과 화면 퍼블리싱

### DIFF
--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:find_toilet/screens/book_mark_screen.dart';
 import 'package:find_toilet/screens/main_screen.dart';
 import 'package:flutter/material.dart';
 

--- a/frontend/lib/screens/main_screen.dart
+++ b/frontend/lib/screens/main_screen.dart
@@ -1,4 +1,9 @@
+import 'package:find_toilet/utilities/style.dart';
+import 'package:find_toilet/utilities/type_enum.dart';
+import 'package:find_toilet/widgets/bottom_sheet.dart';
+import 'package:find_toilet/widgets/box_container.dart';
 import 'package:find_toilet/widgets/search_bar.dart';
+import 'package:find_toilet/widgets/text_widget.dart';
 import 'package:flutter/material.dart';
 
 class Main extends StatelessWidget {
@@ -7,9 +12,30 @@ class Main extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Column(
-        children: const [
-          SearchBar(),
+      body: Stack(
+        children: [
+          Column(
+            mainAxisSize: MainAxisSize.max,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Container(
+                decoration: const BoxDecoration(color: yellowColor),
+                width: MediaQuery.of(context).size.width,
+                height: MediaQuery.of(context).size.height,
+                child: const Center(
+                  child: CustomText(
+                    title: '여기에 지도 들어감 \n 메인 페이지',
+                    fontSize: FontSize.titleSize,
+                    color: CustomColors.whiteColor,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          Column(
+            children: const [SearchBar(isMain: true), FilterBox()],
+          ),
+          const ToiletList(isMain: true),
         ],
       ),
     );

--- a/frontend/lib/screens/main_screen.dart
+++ b/frontend/lib/screens/main_screen.dart
@@ -1,6 +1,4 @@
-import 'package:find_toilet/screens/book_mark_screen.dart';
-import 'package:find_toilet/screens/settings_screen.dart';
-import 'package:find_toilet/utilities/icon.dart';
+import 'package:find_toilet/widgets/search_bar.dart';
 import 'package:flutter/material.dart';
 
 class Main extends StatelessWidget {
@@ -8,25 +6,10 @@ class Main extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    void toBookMark() {
-      Navigator.push(context,
-          MaterialPageRoute(builder: (context) => BookMarkMain(folderCnt: 4)));
-    }
-
-    void toSettings() {
-      Navigator.push(
-          context, MaterialPageRoute(builder: (context) => const Settings()));
-    }
-
     return Scaffold(
-      body: Row(
-        children: [
-          const SizedBox(
-            height: 100,
-          ),
-          IconButton(onPressed: toSettings, icon: const Icon(hamburgerIcon)),
-          const Text('여기는 메인'),
-          IconButton(onPressed: toBookMark, icon: const Icon(starIcon))
+      body: Column(
+        children: const [
+          SearchBar(),
         ],
       ),
     );

--- a/frontend/lib/screens/review_form_screen.dart
+++ b/frontend/lib/screens/review_form_screen.dart
@@ -6,23 +6,23 @@ import 'package:find_toilet/widgets/text_widget.dart';
 import 'package:flutter/material.dart';
 
 class ReviewForm extends StatefulWidget {
-  const ReviewForm({super.key});
+  final String toiletName;
+  const ReviewForm({super.key, required this.toiletName});
 
   @override
   State<ReviewForm> createState() => _ReviewFormState();
 }
 
 class _ReviewFormState extends State<ReviewForm> {
+  int score = -1;
+  void changeScore(int i) {
+    setState(() {
+      score = i;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
-    int score = -1;
-    void changeScore(int i) {
-      // print(i);
-      // setState() {
-      score = i;
-      // }
-    }
-
     return Scaffold(
       backgroundColor: mainColor,
       body: Padding(
@@ -30,8 +30,8 @@ class _ReviewFormState extends State<ReviewForm> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           children: [
-            const CustomText(
-                title: '광주시립도서관화장실',
+            CustomText(
+                title: widget.toiletName,
                 fontSize: FontSize.largeSize,
                 color: CustomColors.whiteColor),
             const CustomText(
@@ -42,13 +42,13 @@ class _ReviewFormState extends State<ReviewForm> {
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 for (int i = 0; i < 5; i += 1)
-                  IconButton(
+                  CustomIconButton(
                     onPressed: () => changeScore(i),
                     icon: Icon(
                       starIcon,
                       color: i <= score ? yellowColor : whiteColor,
-                      size: 40,
                     ),
+                    iconSize: 50,
                   ),
               ],
             ),

--- a/frontend/lib/screens/review_form_screen.dart
+++ b/frontend/lib/screens/review_form_screen.dart
@@ -1,4 +1,4 @@
-import 'package:find_toilet/utilities/icon.dart';
+import 'package:find_toilet/utilities/icondata.dart';
 import 'package:find_toilet/utilities/style.dart';
 import 'package:find_toilet/utilities/type_enum.dart';
 import 'package:find_toilet/widgets/button.dart';

--- a/frontend/lib/screens/search_screen.dart
+++ b/frontend/lib/screens/search_screen.dart
@@ -7,7 +7,8 @@ import 'package:find_toilet/widgets/text_widget.dart';
 import 'package:flutter/material.dart';
 
 class Search extends StatelessWidget {
-  const Search({super.key});
+  final String query;
+  const Search({super.key, required this.query});
 
   @override
   Widget build(BuildContext context) {
@@ -24,7 +25,7 @@ class Search extends StatelessWidget {
                 height: MediaQuery.of(context).size.height,
                 child: const Center(
                   child: CustomText(
-                    title: '여기에 지도 들어감',
+                    title: '여기에 지도 들어감 \n 검색 페이지',
                     fontSize: FontSize.titleSize,
                     color: CustomColors.whiteColor,
                   ),
@@ -33,9 +34,12 @@ class Search extends StatelessWidget {
             ],
           ),
           Column(
-            children: const [SearchBar(), FilterBox()],
+            children: [
+              SearchBar(isMain: false, query: query),
+              const FilterBox()
+            ],
           ),
-          const ToiletList(),
+          const ToiletList(isMain: false),
         ],
       ),
     );

--- a/frontend/lib/screens/search_screen.dart
+++ b/frontend/lib/screens/search_screen.dart
@@ -1,0 +1,93 @@
+import 'package:find_toilet/utilities/style.dart';
+import 'package:find_toilet/utilities/type_enum.dart';
+import 'package:find_toilet/widgets/box_container.dart';
+import 'package:find_toilet/widgets/search_bar.dart';
+import 'package:find_toilet/widgets/select_box.dart';
+import 'package:find_toilet/widgets/text_widget.dart';
+import 'package:flutter/material.dart';
+
+class Search extends StatelessWidget {
+  const Search({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Stack(
+        children: [
+          Column(
+            mainAxisSize: MainAxisSize.max,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              // 여기에 지도
+              Column(
+                children: const [
+                  SearchBar(),
+                  CustomText(
+                    title: '여기에 필터',
+                    fontSize: FontSize.largeSize,
+                    color: CustomColors.blackColor,
+                  ),
+                ],
+              ),
+              const ToiletList(),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class ToiletList extends StatelessWidget {
+  const ToiletList({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    const List<String> sortOrder = ['거리 순', '평점 순', '리뷰 많은 순'];
+    return Positioned(
+      bottom: 0,
+      child: GestureDetector(
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 400),
+          decoration: const BoxDecoration(
+              color: mainColor,
+              borderRadius: BorderRadius.vertical(top: Radius.circular(10))),
+          width: MediaQuery.of(context).size.width,
+          height: 300,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                Container(
+                  width: 70,
+                  height: 4.5,
+                  decoration: const BoxDecoration(
+                      color: whiteColor,
+                      borderRadius: BorderRadius.all(Radius.circular(10))),
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 10),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: const [
+                      CustomText(
+                        title: '검색 결과',
+                        fontSize: FontSize.largeSize,
+                        color: CustomColors.whiteColor,
+                      ),
+                      SelectBox(selectList: sortOrder, width: 100, height: 24)
+                    ],
+                  ),
+                ),
+                const ListItem(),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/screens/search_screen.dart
+++ b/frontend/lib/screens/search_screen.dart
@@ -1,8 +1,8 @@
 import 'package:find_toilet/utilities/style.dart';
 import 'package:find_toilet/utilities/type_enum.dart';
+import 'package:find_toilet/widgets/bottom_sheet.dart';
 import 'package:find_toilet/widgets/box_container.dart';
 import 'package:find_toilet/widgets/search_bar.dart';
-import 'package:find_toilet/widgets/select_box.dart';
 import 'package:find_toilet/widgets/text_widget.dart';
 import 'package:flutter/material.dart';
 
@@ -18,75 +18,25 @@ class Search extends StatelessWidget {
             mainAxisSize: MainAxisSize.max,
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              // 여기에 지도
-              Column(
-                children: const [
-                  SearchBar(),
-                  CustomText(
-                    title: '여기에 필터',
-                    fontSize: FontSize.largeSize,
-                    color: CustomColors.blackColor,
+              Container(
+                decoration: const BoxDecoration(color: yellowColor),
+                width: MediaQuery.of(context).size.width,
+                height: MediaQuery.of(context).size.height,
+                child: const Center(
+                  child: CustomText(
+                    title: '여기에 지도 들어감',
+                    fontSize: FontSize.titleSize,
+                    color: CustomColors.whiteColor,
                   ),
-                ],
+                ),
               ),
-              const ToiletList(),
             ],
           ),
-        ],
-      ),
-    );
-  }
-}
-
-class ToiletList extends StatelessWidget {
-  const ToiletList({
-    super.key,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    const List<String> sortOrder = ['거리 순', '평점 순', '리뷰 많은 순'];
-    return Positioned(
-      bottom: 0,
-      child: GestureDetector(
-        child: AnimatedContainer(
-          duration: const Duration(milliseconds: 400),
-          decoration: const BoxDecoration(
-              color: mainColor,
-              borderRadius: BorderRadius.vertical(top: Radius.circular(10))),
-          width: MediaQuery.of(context).size.width,
-          height: 300,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.spaceAround,
-              children: [
-                Container(
-                  width: 70,
-                  height: 4.5,
-                  decoration: const BoxDecoration(
-                      color: whiteColor,
-                      borderRadius: BorderRadius.all(Radius.circular(10))),
-                ),
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 10),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: const [
-                      CustomText(
-                        title: '검색 결과',
-                        fontSize: FontSize.largeSize,
-                        color: CustomColors.whiteColor,
-                      ),
-                      SelectBox(selectList: sortOrder, width: 100, height: 24)
-                    ],
-                  ),
-                ),
-                const ListItem(),
-              ],
-            ),
+          Column(
+            children: const [SearchBar(), FilterBox()],
           ),
-        ),
+          const ToiletList(),
+        ],
       ),
     );
   }

--- a/frontend/lib/screens/settings_screen.dart
+++ b/frontend/lib/screens/settings_screen.dart
@@ -1,5 +1,5 @@
 import 'package:find_toilet/utilities/settings_utils.dart';
-import 'package:find_toilet/utilities/icon.dart';
+import 'package:find_toilet/utilities/icondata.dart';
 import 'package:find_toilet/utilities/type_enum.dart';
 import 'package:find_toilet/widgets/button.dart';
 import 'package:find_toilet/widgets/text_widget.dart';

--- a/frontend/lib/utilities/icon.dart
+++ b/frontend/lib/utilities/icon.dart
@@ -18,3 +18,6 @@ const licenseIcon = Icons.brightness_7_outlined;
 
 const planeIcon = Icons.near_me_outlined;
 const bookMarkIcon = Icons.bookmark_border;
+
+const searchIcon = Icons.search_rounded;
+const closeIcon = Icons.close;

--- a/frontend/lib/utilities/icon.dart
+++ b/frontend/lib/utilities/icon.dart
@@ -1,3 +1,4 @@
+import 'package:find_toilet/utilities/style.dart';
 import 'package:flutter/material.dart';
 
 const locationIcon = Icons.location_on;
@@ -5,7 +6,7 @@ const locationIcon = Icons.location_on;
 const phoneIcon = Icons.phone_rounded;
 const clockIcon = Icons.access_time_filled_rounded;
 const starIcon = Icons.star_rounded;
-const hamburgerIcon = Icons.menu;
+const hamburgerIcon = Icon(Icons.menu);
 const personIcon = Icons.person;
 const scaleIcon = Icons.hdr_strong_rounded;
 // const scaleIcon = Icons.iso_rounded;
@@ -17,7 +18,11 @@ const policyIcon = Icons.article_rounded;
 const licenseIcon = Icons.brightness_7_outlined;
 
 const planeIcon = Icons.near_me_outlined;
-const bookMarkIcon = Icons.bookmark_border;
+const bookMarkIcon = Icon(Icons.bookmark_border);
 
-const searchIcon = Icons.search_rounded;
-const closeIcon = Icons.close;
+const searchIcon = Icon(Icons.search_rounded);
+const closeIcon = Icon(Icons.close);
+
+//* filter 선택
+const toLeftIcon = Icon(Icons.arrow_left_sharp, color: mainColor);
+const toRightIcon = Icon(Icons.arrow_right_sharp, color: mainColor);

--- a/frontend/lib/utilities/icondata.dart
+++ b/frontend/lib/utilities/icondata.dart
@@ -17,12 +17,18 @@ const inquiryIcon = Icons.outgoing_mail;
 const policyIcon = Icons.article_rounded;
 const licenseIcon = Icons.brightness_7_outlined;
 
-const planeIcon = Icons.near_me_outlined;
+const planeIcon = Icons.near_me;
 const bookMarkIcon = Icon(Icons.bookmark_border);
 
 const searchIcon = Icon(Icons.search_rounded);
 const closeIcon = Icon(Icons.close);
 
+const plusIcon = Icons.add;
+
 //* filter 선택
 const toLeftIcon = Icon(Icons.arrow_left_sharp, color: mainColor);
 const toRightIcon = Icon(Icons.arrow_right_sharp, color: mainColor);
+const toDownIcon = Icons.arrow_drop_down;
+
+const heartIcon = Icons.favorite;
+const emptyHeartIcon = Icons.favorite_border_rounded;

--- a/frontend/lib/utilities/settings_utils.dart
+++ b/frontend/lib/utilities/settings_utils.dart
@@ -1,4 +1,4 @@
-import 'package:find_toilet/utilities/icon.dart';
+import 'package:find_toilet/utilities/icondata.dart';
 import 'package:find_toilet/utilities/type_enum.dart';
 
 final StringList menuList = [

--- a/frontend/lib/utilities/style.dart
+++ b/frontend/lib/utilities/style.dart
@@ -1,7 +1,7 @@
 import 'package:find_toilet/utilities/type_enum.dart';
 import 'package:flutter/material.dart';
 
-//** 색 관련
+//* 색 관련
 const mainColor = Color(0xFF5957D4);
 const whiteColor = Colors.white;
 const blackColor = Colors.black;
@@ -23,7 +23,7 @@ Color convertedColor(CustomColors color) {
   }
 }
 
-//** 글씨 관련
+//* 글씨 관련
 const double titleSize = 30;
 const double largeSize = 24;
 const double defaultSize = 19;
@@ -44,4 +44,4 @@ double convertedSize(FontSize size) {
 
 //* 그림자
 const defaultShadow = BoxShadow(
-    color: greyColor, blurRadius: 5, spreadRadius: 0, offset: Offset(0.5, 0.5));
+    color: greyColor, blurRadius: 1, spreadRadius: 0.1, offset: Offset(0, 1));

--- a/frontend/lib/utilities/style.dart
+++ b/frontend/lib/utilities/style.dart
@@ -6,7 +6,8 @@ const mainColor = Color(0xFF5957D4);
 const whiteColor = Colors.white;
 const blackColor = Colors.black;
 const redColor = Colors.red;
-const yellowColor = Colors.yellow;
+const yellowColor = Color(0xFFFFBF44);
+const greyColor = Colors.grey;
 Color convertedColor(CustomColors color) {
   switch (color) {
     case CustomColors.whiteColor:
@@ -40,3 +41,7 @@ double convertedSize(FontSize size) {
       return defaultSize;
   }
 }
+
+//* 그림자
+const defaultShadow = BoxShadow(
+    color: greyColor, blurRadius: 5, spreadRadius: 0, offset: Offset(0.5, 0.5));

--- a/frontend/lib/utilities/type_enum.dart
+++ b/frontend/lib/utilities/type_enum.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 typedef WidgetList = List<Widget>;
 typedef StringList = List<String>;
 typedef IntList = List<int>;
+typedef BoolList = List<bool>;
 typedef IconDataList = List<IconData>;
 typedef ReturnVoid = void Function();
 typedef VoidFuncList = List<ReturnVoid>;

--- a/frontend/lib/widgets/bottom_sheet.dart
+++ b/frontend/lib/widgets/bottom_sheet.dart
@@ -1,0 +1,133 @@
+import 'package:find_toilet/utilities/style.dart';
+import 'package:find_toilet/utilities/type_enum.dart';
+import 'package:find_toilet/widgets/box_container.dart';
+import 'package:find_toilet/widgets/select_box.dart';
+import 'package:find_toilet/widgets/text_widget.dart';
+import 'package:flutter/material.dart';
+
+class ToiletList extends StatefulWidget {
+  const ToiletList({
+    super.key,
+  });
+
+  @override
+  State<ToiletList> createState() => _ToiletListState();
+}
+
+class _ToiletListState extends State<ToiletList> {
+  late double height;
+  final double lowLimit = 300;
+  final double upThresh = 300;
+  final double boundary = 500;
+  final double downThresh = 550;
+  bool longAnimation = false;
+
+  @override
+  void initState() {
+    super.initState();
+    height = lowLimit;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const List<String> sortOrder = ['거리 순', '평점 순', '리뷰 많은 순'];
+    final double highLimit = MediaQuery.of(context).size.height * 0.9;
+    return Positioned(
+      bottom: 0,
+      child: GestureDetector(
+        onVerticalDragUpdate: ((details) {
+          // delta: y축의 변화량, 우리가 보기에 위로 움직이면 양의 값, 아래로 움직이면 음의 값
+          double? delta = details.primaryDelta;
+          if (delta != null) {
+            /// Long Animation이 진행 되고 있을 때는 드래그로 높이 변화 방지,
+            /// 그리고 low limit 보다 작을 때 delta가 양수,
+            /// High limit 보다 크거나 같을 때 delta가 음수이면 드래그로 높이 변화 방지
+            if (longAnimation ||
+                (height <= lowLimit && delta > 0) ||
+                (height >= highLimit && delta < 0)) return;
+            setState(() {
+              /// 600으로 높이 설정
+              if (upThresh <= height && height <= boundary) {
+                height = highLimit;
+                longAnimation = true;
+              }
+
+              /// 100으로 높이 설정
+              else if (boundary <= height && height <= downThresh) {
+                height = lowLimit;
+                longAnimation = true;
+              }
+
+              /// 기본 작동
+              else {
+                height -= delta;
+              }
+            });
+          }
+        }),
+        child: AnimatedContainer(
+          curve: Curves.bounceOut,
+          onEnd: () {
+            if (longAnimation) {
+              setState(() {
+                longAnimation = false;
+              });
+            }
+          },
+          duration: const Duration(milliseconds: 400),
+          decoration: const BoxDecoration(
+              color: mainColor,
+              borderRadius: BorderRadius.vertical(top: Radius.circular(10))),
+          width: MediaQuery.of(context).size.width,
+          height: height,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Container(
+                //   width: 70,
+                //   height: 4.5,
+                //   decoration: const BoxDecoration(
+                //       color: whiteColor,
+                //       borderRadius: BorderRadius.all(Radius.circular(10))),
+                // ),
+                Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 10, vertical: 15),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: const [
+                      CustomText(
+                        title: '검색 결과',
+                        fontSize: FontSize.largeSize,
+                        color: CustomColors.whiteColor,
+                      ),
+                      SelectBox(selectList: sortOrder, width: 100, height: 30)
+                    ],
+                  ),
+                ),
+                const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 10),
+                  child: CustomText(
+                    title: '필터를 적용해 검색한 결과입니다',
+                    fontSize: FontSize.smallSize,
+                    color: CustomColors.whiteColor,
+                    font: 'Noto Sans',
+                  ),
+                ),
+                Column(
+                  children: const [
+                    ListItem(),
+                    ListItem(),
+                    ListItem(),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/widgets/bottom_sheet.dart
+++ b/frontend/lib/widgets/bottom_sheet.dart
@@ -6,9 +6,8 @@ import 'package:find_toilet/widgets/text_widget.dart';
 import 'package:flutter/material.dart';
 
 class ToiletList extends StatefulWidget {
-  const ToiletList({
-    super.key,
-  });
+  final bool isMain;
+  const ToiletList({super.key, required this.isMain});
 
   @override
   State<ToiletList> createState() => _ToiletListState();
@@ -31,7 +30,7 @@ class _ToiletListState extends State<ToiletList> {
   @override
   Widget build(BuildContext context) {
     const List<String> sortOrder = ['거리 순', '평점 순', '리뷰 많은 순'];
-    final double highLimit = MediaQuery.of(context).size.height * 0.9;
+    final double highLimit = MediaQuery.of(context).size.height * 0.8;
     return Positioned(
       bottom: 0,
       child: GestureDetector(
@@ -97,20 +96,23 @@ class _ToiletListState extends State<ToiletList> {
                       const EdgeInsets.symmetric(horizontal: 10, vertical: 15),
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: const [
+                    children: [
                       CustomText(
-                        title: '검색 결과',
+                        title: widget.isMain ? '주변 화장실' : '검색 결과',
                         fontSize: FontSize.largeSize,
                         color: CustomColors.whiteColor,
                       ),
-                      SelectBox(selectList: sortOrder, width: 100, height: 30)
+                      widget.isMain
+                          ? const SizedBox()
+                          : const SelectBox(
+                              selectList: sortOrder, width: 120, height: 30)
                     ],
                   ),
                 ),
                 const Padding(
                   padding: EdgeInsets.symmetric(horizontal: 10),
                   child: CustomText(
-                    title: '필터를 적용해 검색한 결과입니다',
+                    title: '필터를 적용한 결과입니다',
                     fontSize: FontSize.smallSize,
                     color: CustomColors.whiteColor,
                     font: 'Noto Sans',

--- a/frontend/lib/widgets/box_container.dart
+++ b/frontend/lib/widgets/box_container.dart
@@ -1,9 +1,10 @@
 import 'package:find_toilet/screens/book_mark_screen.dart';
 import 'package:find_toilet/screens/review_form_screen.dart';
-import 'package:find_toilet/utilities/icon.dart';
+import 'package:find_toilet/utilities/icondata.dart';
 import 'package:find_toilet/utilities/style.dart';
 import 'package:find_toilet/utilities/type_enum.dart';
 import 'package:find_toilet/widgets/button.dart';
+import 'package:find_toilet/widgets/icon.dart';
 import 'package:find_toilet/widgets/modal.dart';
 import 'package:find_toilet/widgets/text_widget.dart';
 import 'package:flutter/material.dart';
@@ -226,23 +227,25 @@ class _AddBoxState extends State<AddBox> {
         width: 150,
         color: whiteColor,
         child: const Center(
-            child: Icon(
-          Icons.add,
-          color: mainColor,
-          size: 50,
-        )),
+          child: CustomIcon(
+            icon: plusIcon,
+            color: mainColor,
+            size: 50,
+          ),
+        ),
       ),
     );
   }
 }
 
 //* 장소 목록 아이템
-class ListItem extends StatelessWidget {
+class ListItem extends StatefulWidget {
   final String font;
   final StringList available;
   final String toiletName, address, phoneNo, duration;
   final double score;
   final int reviewCnt;
+  final bool isLiked;
   const ListItem({
     super.key,
     this.font = 'Noto Sans',
@@ -253,7 +256,26 @@ class ListItem extends StatelessWidget {
     this.score = 4.3,
     this.reviewCnt = 30,
     this.available = const ['장애인용', '유아용', '기저귀 교환대'],
+    this.isLiked = false,
   });
+
+  @override
+  State<ListItem> createState() => _ListItemState();
+}
+
+class _ListItemState extends State<ListItem> {
+  late bool liked;
+  void changeLiked() {
+    setState(() {
+      liked = !liked;
+    });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    liked = widget.isLiked;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -261,107 +283,110 @@ class ListItem extends StatelessWidget {
       Navigator.push(
           context,
           MaterialPageRoute(
-              builder: (context) => const ReviewForm(
-                    toiletName: '광주시립도서관화장실',
-                  )));
+              builder: (context) => ReviewForm(toiletName: widget.toiletName)));
     }
 
     return Padding(
       padding: const EdgeInsets.only(top: 20),
-      child: CommonBox(
-        color: whiteColor,
-        height: 200,
-        width: 500,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 20),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
-            children: [
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  CustomText(
-                      color: CustomColors.mainColor,
-                      title: toiletName,
-                      fontSize: FontSize.defaultSize,
-                      font: font),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    children: [
-                      IconButton(
-                          onPressed: () {},
-                          icon: const Icon(
-                            Icons.favorite_rounded,
-                            color: redColor,
-                          )),
-                      IconButton(
-                          onPressed: () {
-                            showDialog(
-                                context: context,
-                                builder: (context) => const NavigationModal());
-                          },
-                          icon: const Icon(
-                            Icons.send,
-                            color: Colors.lightBlue,
-                          )),
-                    ],
-                  ),
-                ],
-              ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  TextWithIcon(
-                    icon: locationIcon,
-                    text: address,
-                    font: font,
-                  ),
-                  TextWithIcon(
-                    icon: phoneIcon,
-                    text: phoneNo,
-                    font: font,
-                  ),
-                ],
-              ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  TextWithIcon(
-                    icon: clockIcon,
-                    text: duration,
-                    textColor: CustomColors.blackColor,
-                    font: font,
-                  ),
-                  TextWithIcon(
-                      icon: starIcon,
-                      text: '$score ($reviewCnt개)',
-                      iconColor: CustomColors.yellowColor,
-                      font: font),
-                ],
-              ),
-              CustomText(
-                title: '이용 가능 시설',
-                fontSize: FontSize.smallSize,
-                color: CustomColors.mainColor,
-                font: font,
-              ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                children: [
-                  for (String each in available)
+      child: GestureDetector(
+        onTap: () {},
+        child: CommonBox(
+          color: whiteColor,
+          height: 200,
+          width: 500,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 20),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
                     CustomText(
-                      title: each,
-                      fontSize: FontSize.smallSize,
-                      color: CustomColors.blackColor,
-                      font: font,
+                        color: CustomColors.mainColor,
+                        title: widget.toiletName,
+                        fontSize: FontSize.defaultSize,
+                        font: widget.font),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: [
+                        IconButton(
+                          onPressed: changeLiked,
+                          icon: CustomIcon(
+                              icon: liked ? heartIcon : emptyHeartIcon,
+                              color: redColor),
+                        ),
+                        IconButton(
+                            onPressed: () {
+                              showDialog(
+                                  context: context,
+                                  builder: (context) =>
+                                      const NavigationModal());
+                            },
+                            icon: const CustomIcon(
+                              icon: planeIcon,
+                              color: Colors.lightBlue,
+                              size: 35,
+                            )),
+                      ],
                     ),
-                  CustomButton(
-                    onPressed: toReview,
-                    buttonText: '리뷰 남기기',
-                  )
-                ],
-              )
-            ],
+                  ],
+                ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    TextWithIcon(
+                      icon: locationIcon,
+                      text: widget.address,
+                      font: widget.font,
+                    ),
+                    TextWithIcon(
+                      icon: phoneIcon,
+                      text: widget.phoneNo,
+                      font: widget.font,
+                    ),
+                  ],
+                ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    TextWithIcon(
+                      icon: clockIcon,
+                      text: widget.duration,
+                      textColor: CustomColors.blackColor,
+                      font: widget.font,
+                    ),
+                    TextWithIcon(
+                        icon: starIcon,
+                        text: '${widget.score} (${widget.reviewCnt}개)',
+                        iconColor: CustomColors.yellowColor,
+                        font: widget.font),
+                  ],
+                ),
+                CustomText(
+                  title: '이용 가능 시설',
+                  fontSize: FontSize.smallSize,
+                  color: CustomColors.mainColor,
+                  font: widget.font,
+                ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    for (String each in widget.available)
+                      CustomText(
+                        title: each,
+                        fontSize: FontSize.smallSize,
+                        color: CustomColors.blackColor,
+                        font: widget.font,
+                      ),
+                    CustomButton(
+                      onPressed: toReview,
+                      buttonText: '리뷰 남기기',
+                    )
+                  ],
+                )
+              ],
+            ),
           ),
         ),
       ),
@@ -418,7 +443,7 @@ class _FilterBoxState extends State<FilterBox> {
                       const EdgeInsets.symmetric(vertical: 10, horizontal: 12),
                   child: CustomText(
                     title: showedFilter[i],
-                    fontSize: FontSize.defaultSize,
+                    fontSize: FontSize.smallSize,
                     color: selectedList[i]
                         ? CustomColors.whiteColor
                         : CustomColors.blackColor,

--- a/frontend/lib/widgets/box_container.dart
+++ b/frontend/lib/widgets/box_container.dart
@@ -8,7 +8,7 @@ import 'package:find_toilet/widgets/modal.dart';
 import 'package:find_toilet/widgets/text_widget.dart';
 import 'package:flutter/material.dart';
 
-//* 테마 선택 시의 상처
+//* 테마 선택 시의 상자
 class ThemeBox extends StatefulWidget {
   final String text;
   late bool selected;
@@ -239,126 +239,196 @@ class _AddBoxState extends State<AddBox> {
 //* 장소 목록 아이템
 class ListItem extends StatelessWidget {
   final String font;
-  final StringList? available;
+  final StringList available;
+  final String toiletName, address, phoneNo, duration;
+  final double score;
+  final int reviewCnt;
   const ListItem({
     super.key,
     this.font = 'Noto Sans',
-    this.available,
+    this.toiletName = '광주시립도서관화장실',
+    this.address = '광주광역시 북구 어쩌고길',
+    this.phoneNo = '062-xxx-xxxx',
+    this.duration = '00:00 - 00:00',
+    this.score = 4.3,
+    this.reviewCnt = 30,
+    this.available = const ['장애인용', '유아용', '기저귀 교환대'],
   });
 
   @override
   Widget build(BuildContext context) {
     void toReview() {
       Navigator.push(
-          context, MaterialPageRoute(builder: (context) => const ReviewForm()));
+          context,
+          MaterialPageRoute(
+              builder: (context) => const ReviewForm(
+                    toiletName: '광주시립도서관화장실',
+                  )));
     }
 
-    return CommonBox(
-      color: whiteColor,
-      height: 200,
-      width: 500,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 20),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.spaceAround,
-          children: [
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                CustomText(
-                    color: CustomColors.mainColor,
-                    title: '광주시립도서관화장실',
-                    fontSize: FontSize.defaultSize,
-                    font: font),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: [
-                    IconButton(
-                        onPressed: () {},
-                        icon: const Icon(
-                          Icons.favorite_rounded,
-                          color: redColor,
-                        )),
-                    IconButton(
-                        onPressed: () {
-                          showDialog(
-                              context: context,
-                              builder: (context) => const NavigationModal());
-                        },
-                        icon: const Icon(
-                          Icons.send,
-                          color: Colors.lightBlue,
-                        )),
-                  ],
-                ),
-              ],
-            ),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                TextWithIcon(
-                  icon: locationIcon,
-                  text: '광주광역시 북구 어쩌고길',
-                  font: font,
-                ),
-                TextWithIcon(
-                  icon: phoneIcon,
-                  text: '062-xxxx-xxxx',
-                  font: font,
-                ),
-              ],
-            ),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                TextWithIcon(
-                  icon: clockIcon,
-                  text: '00:00 - 00:00',
-                  textColor: CustomColors.blackColor,
-                  font: font,
-                ),
-                TextWithIcon(
-                    icon: starIcon,
-                    text: '4.3 (30개)',
-                    iconColor: CustomColors.yellowColor,
-                    font: font),
-              ],
-            ),
-            CustomText(
-              title: '이용 가능 시설',
-              fontSize: FontSize.smallSize,
-              color: CustomColors.mainColor,
-              font: font,
-            ),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: [
-                CustomText(
-                  title: '장애인용',
-                  fontSize: FontSize.smallSize,
-                  color: CustomColors.blackColor,
-                  font: font,
-                ),
-                CustomText(
-                    title: '유아용',
-                    fontSize: FontSize.smallSize,
-                    color: CustomColors.blackColor,
-                    font: font),
-                CustomText(
-                  title: '기저귀 교환대',
-                  fontSize: FontSize.smallSize,
-                  color: CustomColors.blackColor,
-                  font: font,
-                ),
-                CustomButton(
-                  onPressed: toReview,
-                  buttonText: '리뷰 남기기',
-                )
-              ],
-            )
-          ],
+    return Padding(
+      padding: const EdgeInsets.only(top: 20),
+      child: CommonBox(
+        color: whiteColor,
+        height: 200,
+        width: 500,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 20),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  CustomText(
+                      color: CustomColors.mainColor,
+                      title: toiletName,
+                      fontSize: FontSize.defaultSize,
+                      font: font),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      IconButton(
+                          onPressed: () {},
+                          icon: const Icon(
+                            Icons.favorite_rounded,
+                            color: redColor,
+                          )),
+                      IconButton(
+                          onPressed: () {
+                            showDialog(
+                                context: context,
+                                builder: (context) => const NavigationModal());
+                          },
+                          icon: const Icon(
+                            Icons.send,
+                            color: Colors.lightBlue,
+                          )),
+                    ],
+                  ),
+                ],
+              ),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  TextWithIcon(
+                    icon: locationIcon,
+                    text: address,
+                    font: font,
+                  ),
+                  TextWithIcon(
+                    icon: phoneIcon,
+                    text: phoneNo,
+                    font: font,
+                  ),
+                ],
+              ),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  TextWithIcon(
+                    icon: clockIcon,
+                    text: duration,
+                    textColor: CustomColors.blackColor,
+                    font: font,
+                  ),
+                  TextWithIcon(
+                      icon: starIcon,
+                      text: '$score ($reviewCnt개)',
+                      iconColor: CustomColors.yellowColor,
+                      font: font),
+                ],
+              ),
+              CustomText(
+                title: '이용 가능 시설',
+                fontSize: FontSize.smallSize,
+                color: CustomColors.mainColor,
+                font: font,
+              ),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  for (String each in available)
+                    CustomText(
+                      title: each,
+                      fontSize: FontSize.smallSize,
+                      color: CustomColors.blackColor,
+                      font: font,
+                    ),
+                  CustomButton(
+                    onPressed: toReview,
+                    buttonText: '리뷰 남기기',
+                  )
+                ],
+              )
+            ],
+          ),
         ),
       ),
+    );
+  }
+}
+
+//* filter 상자, 화살표
+class FilterBox extends StatefulWidget {
+  const FilterBox({super.key});
+
+  @override
+  State<FilterBox> createState() => _FilterBoxState();
+}
+
+class _FilterBoxState extends State<FilterBox> {
+  int length = 4;
+  StringList filterList = ['기저귀', '유아용', '장애인', '24시간'];
+  late StringList showedFilter;
+  late BoolList selectedList;
+  void changeSelected(int i) {
+    setState(() {
+      selectedList[i] = !selectedList[i];
+    });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    showedFilter = [for (int i = 0; i < 3; i += 1) filterList[i]];
+    selectedList = [for (int i = 0; i < length; i += 1) false];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        CustomIconButton(icon: toLeftIcon, iconSize: 50, onPressed: () {}),
+        for (int i = 0; i < 3; i += 1)
+          GestureDetector(
+            onTap: () => changeSelected(i),
+            child: Container(
+              // width: 100,
+              // height: 30,
+              decoration: BoxDecoration(
+                  color: selectedList[i] ? mainColor : whiteColor,
+                  borderRadius: BorderRadius.circular(5),
+                  boxShadow: const [defaultShadow]),
+              child: Center(
+                child: Padding(
+                  padding:
+                      const EdgeInsets.symmetric(vertical: 10, horizontal: 12),
+                  child: CustomText(
+                    title: showedFilter[i],
+                    fontSize: FontSize.defaultSize,
+                    color: selectedList[i]
+                        ? CustomColors.whiteColor
+                        : CustomColors.blackColor,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        CustomIconButton(icon: toRightIcon, iconSize: 50, onPressed: () {}),
+      ],
     );
   }
 }

--- a/frontend/lib/widgets/button.dart
+++ b/frontend/lib/widgets/button.dart
@@ -13,9 +13,7 @@ class CustomButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return OutlinedButton(
       onPressed: onPressed,
-      child: Text(
-        buttonText,
-      ),
+      child: Text(buttonText),
     );
   }
 }
@@ -44,6 +42,29 @@ class ExitPage extends StatelessWidget {
           )
         ],
       ),
+    );
+  }
+}
+
+class CustomIconButton extends StatelessWidget {
+  final Icon icon;
+  final double iconSize;
+  final ReturnVoid onPressed;
+  const CustomIconButton({
+    super.key,
+    required this.icon,
+    required this.iconSize,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      padding: EdgeInsets.zero,
+      constraints: const BoxConstraints(),
+      onPressed: onPressed,
+      icon: icon,
+      iconSize: iconSize,
     );
   }
 }

--- a/frontend/lib/widgets/button.dart
+++ b/frontend/lib/widgets/button.dart
@@ -68,3 +68,32 @@ class CustomIconButton extends StatelessWidget {
     );
   }
 }
+
+class CustomCircleButton extends StatelessWidget {
+  final Color color;
+  final bool shadow;
+  final double width, height;
+  final Widget child;
+
+  const CustomCircleButton({
+    super.key,
+    this.color = whiteColor,
+    this.shadow = true,
+    required this.width,
+    required this.height,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          color: color,
+          boxShadow: shadow ? [defaultShadow] : null),
+      width: width,
+      height: height,
+      child: child,
+    );
+  }
+}

--- a/frontend/lib/widgets/icon.dart
+++ b/frontend/lib/widgets/icon.dart
@@ -1,0 +1,15 @@
+import 'package:find_toilet/utilities/style.dart';
+import 'package:flutter/material.dart';
+
+class CustomIcon extends StatelessWidget {
+  final Color color;
+  final double size;
+  final IconData icon;
+  const CustomIcon(
+      {super.key, this.color = blackColor, this.size = 30, required this.icon});
+
+  @override
+  Widget build(BuildContext context) {
+    return Icon(icon, color: color, size: size);
+  }
+}

--- a/frontend/lib/widgets/search_bar.dart
+++ b/frontend/lib/widgets/search_bar.dart
@@ -1,0 +1,72 @@
+import 'package:find_toilet/screens/book_mark_screen.dart';
+import 'package:find_toilet/screens/main_screen.dart';
+import 'package:find_toilet/screens/search_screen.dart';
+import 'package:find_toilet/screens/settings_screen.dart';
+import 'package:find_toilet/utilities/icon.dart';
+import 'package:find_toilet/utilities/style.dart';
+import 'package:flutter/material.dart';
+
+class SearchBar extends StatefulWidget {
+  const SearchBar({
+    super.key,
+  });
+
+  @override
+  State<SearchBar> createState() => _SearchBarState();
+}
+
+class _SearchBarState extends State<SearchBar> {
+  @override
+  Widget build(BuildContext context) {
+    void toBookMark() {
+      Navigator.push(context,
+          MaterialPageRoute(builder: (context) => BookMarkMain(folderCnt: 4)));
+    }
+
+    void toSettings() {
+      Navigator.push(
+          context, MaterialPageRoute(builder: (context) => const Settings()));
+    }
+
+    void toSearch() {
+      Navigator.push(
+          context, MaterialPageRoute(builder: (context) => const Search()));
+    }
+
+    void toMain() {
+      Navigator.push(
+          context, MaterialPageRoute(builder: (context) => const Main()));
+    }
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        const SizedBox(
+          height: 100,
+        ),
+        // IconButton(onPressed: toSettings, icon: const Icon(hamburgerIcon)),
+        SizedBox(
+          width: 250,
+          height: 40,
+          child: TextField(
+            // autofocus: false,
+            decoration: InputDecoration(
+                // icon: Icon(searchIcon),
+                hintText: '검색어를 입력하세요',
+                focusedBorder: const OutlineInputBorder(),
+                focusColor: mainColor,
+                prefixIcon: IconButton(
+                    onPressed: toSettings, icon: const Icon(hamburgerIcon)),
+                suffixIcon: IconButton(
+                  icon: const Icon(closeIcon),
+                  onPressed: toMain,
+                )),
+          ),
+        ),
+        // const TextField(maxLines: 1),
+        IconButton(onPressed: toSearch, icon: const Icon(searchIcon)),
+        IconButton(onPressed: toBookMark, icon: const Icon(bookMarkIcon))
+      ],
+    );
+  }
+}

--- a/frontend/lib/widgets/search_bar.dart
+++ b/frontend/lib/widgets/search_bar.dart
@@ -2,15 +2,15 @@ import 'package:find_toilet/screens/book_mark_screen.dart';
 import 'package:find_toilet/screens/main_screen.dart';
 import 'package:find_toilet/screens/search_screen.dart';
 import 'package:find_toilet/screens/settings_screen.dart';
-import 'package:find_toilet/utilities/icon.dart';
+import 'package:find_toilet/utilities/icondata.dart';
 import 'package:find_toilet/utilities/style.dart';
 import 'package:find_toilet/widgets/button.dart';
 import 'package:flutter/material.dart';
 
 class SearchBar extends StatefulWidget {
-  const SearchBar({
-    super.key,
-  });
+  final bool isMain;
+  final String? query;
+  const SearchBar({super.key, required this.isMain, this.query});
 
   @override
   State<SearchBar> createState() => _SearchBarState();
@@ -31,7 +31,11 @@ class _SearchBarState extends State<SearchBar> {
 
     void toSearch() {
       Navigator.push(
-          context, MaterialPageRoute(builder: (context) => const Search()));
+          context,
+          MaterialPageRoute(
+              builder: (context) => const Search(
+                    query: '광주',
+                  )));
     }
 
     void toMain() {
@@ -43,7 +47,6 @@ class _SearchBarState extends State<SearchBar> {
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
       children: [
         const SizedBox(height: 100),
-        // IconButton(onPressed: toSettings, icon: const Icon(hamburgerIcon)),
         Container(
           width: 270,
           height: 40,
@@ -52,23 +55,30 @@ class _SearchBarState extends State<SearchBar> {
               color: whiteColor,
               borderRadius: BorderRadius.circular(5)),
           child: TextField(
+            controller: widget.isMain
+                ? null
+                : TextEditingController(text: widget.query),
             style: const TextStyle(fontFamily: 'Noto Sans'),
-            // autofocus: false,
             decoration: InputDecoration(
-                // icon: Icon(searchIcon),
-                hintText: '검색어를 입력하세요',
-                // focusedBorder: const OutlineInputBorder(),
-                // focusColor: mainColor,
-                prefixIcon: CustomIconButton(
-                    icon: hamburgerIcon, iconSize: 30, onPressed: toSettings),
-                suffixIcon: CustomIconButton(
-                    icon: closeIcon, iconSize: 30, onPressed: toMain)),
+              border: InputBorder.none,
+              hintText: '검색어를 입력하세요',
+              prefixIcon: CustomIconButton(
+                  icon: hamburgerIcon, iconSize: 30, onPressed: toSettings),
+              suffixIcon: CustomIconButton(
+                  icon: closeIcon, iconSize: 30, onPressed: toMain),
+            ),
           ),
         ),
-        // const TextField(maxLines: 1),
-        CustomIconButton(onPressed: toSearch, icon: searchIcon, iconSize: 30),
-        CustomIconButton(
-            onPressed: toBookMark, icon: bookMarkIcon, iconSize: 30)
+        CustomCircleButton(
+            width: 40,
+            height: 40,
+            child: CustomIconButton(
+                onPressed: toSearch, icon: searchIcon, iconSize: 30)),
+        CustomCircleButton(
+            width: 40,
+            height: 40,
+            child: CustomIconButton(
+                onPressed: toBookMark, icon: bookMarkIcon, iconSize: 30)),
       ],
     );
   }

--- a/frontend/lib/widgets/search_bar.dart
+++ b/frontend/lib/widgets/search_bar.dart
@@ -4,6 +4,7 @@ import 'package:find_toilet/screens/search_screen.dart';
 import 'package:find_toilet/screens/settings_screen.dart';
 import 'package:find_toilet/utilities/icon.dart';
 import 'package:find_toilet/utilities/style.dart';
+import 'package:find_toilet/widgets/button.dart';
 import 'package:flutter/material.dart';
 
 class SearchBar extends StatefulWidget {
@@ -39,33 +40,35 @@ class _SearchBarState extends State<SearchBar> {
     }
 
     return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
       children: [
-        const SizedBox(
-          height: 100,
-        ),
+        const SizedBox(height: 100),
         // IconButton(onPressed: toSettings, icon: const Icon(hamburgerIcon)),
-        SizedBox(
-          width: 250,
+        Container(
+          width: 270,
           height: 40,
+          decoration: BoxDecoration(
+              boxShadow: const [defaultShadow],
+              color: whiteColor,
+              borderRadius: BorderRadius.circular(5)),
           child: TextField(
+            style: const TextStyle(fontFamily: 'Noto Sans'),
             // autofocus: false,
             decoration: InputDecoration(
                 // icon: Icon(searchIcon),
                 hintText: '검색어를 입력하세요',
-                focusedBorder: const OutlineInputBorder(),
-                focusColor: mainColor,
-                prefixIcon: IconButton(
-                    onPressed: toSettings, icon: const Icon(hamburgerIcon)),
-                suffixIcon: IconButton(
-                  icon: const Icon(closeIcon),
-                  onPressed: toMain,
-                )),
+                // focusedBorder: const OutlineInputBorder(),
+                // focusColor: mainColor,
+                prefixIcon: CustomIconButton(
+                    icon: hamburgerIcon, iconSize: 30, onPressed: toSettings),
+                suffixIcon: CustomIconButton(
+                    icon: closeIcon, iconSize: 30, onPressed: toMain)),
           ),
         ),
         // const TextField(maxLines: 1),
-        IconButton(onPressed: toSearch, icon: const Icon(searchIcon)),
-        IconButton(onPressed: toBookMark, icon: const Icon(bookMarkIcon))
+        CustomIconButton(onPressed: toSearch, icon: searchIcon, iconSize: 30),
+        CustomIconButton(
+            onPressed: toBookMark, icon: bookMarkIcon, iconSize: 30)
       ],
     );
   }

--- a/frontend/lib/widgets/select_box.dart
+++ b/frontend/lib/widgets/select_box.dart
@@ -36,7 +36,7 @@ class _SelectBox extends State<SelectBox> {
             itemHeight: 50,
             value: dropdownValue,
             icon: const Icon(Icons.arrow_drop_down),
-            elevation: 16,
+            // elevation: 16,
             style: const TextStyle(color: Colors.black),
             onChanged: (String? value) {
               setState(() {

--- a/frontend/lib/widgets/select_box.dart
+++ b/frontend/lib/widgets/select_box.dart
@@ -1,4 +1,6 @@
+import 'package:find_toilet/utilities/icondata.dart';
 import 'package:find_toilet/utilities/style.dart';
+import 'package:find_toilet/widgets/icon.dart';
 import 'package:flutter/material.dart';
 
 class SelectBox extends StatefulWidget {
@@ -29,29 +31,30 @@ class _SelectBox extends State<SelectBox> {
       height: widget.height,
       decoration: BoxDecoration(
           color: whiteColor, borderRadius: BorderRadius.circular(5)),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          DropdownButton<String>(
-            itemHeight: 50,
-            value: dropdownValue,
-            icon: const Icon(Icons.arrow_drop_down),
-            // elevation: 16,
-            style: const TextStyle(color: Colors.black),
-            onChanged: (String? value) {
-              setState(() {
-                dropdownValue = value!;
-              });
-            },
-            items:
-                widget.selectList.map<DropdownMenuItem<String>>((String value) {
-              return DropdownMenuItem<String>(
-                value: value,
+      child: DropdownButtonHideUnderline(
+        child: DropdownButton<String>(
+          elevation: 10,
+          value: dropdownValue,
+          icon: const CustomIcon(icon: toDownIcon, size: 20),
+          // menuMaxHeight: widget.height * widget.selectList.length,
+          // elevation: 16,
+          style: const TextStyle(color: blackColor),
+          onChanged: (String? value) {
+            setState(() {
+              dropdownValue = value!;
+            });
+          },
+          items:
+              widget.selectList.map<DropdownMenuItem<String>>((String value) {
+            return DropdownMenuItem<String>(
+              value: value,
+              child: SizedBox(
+                height: widget.height,
                 child: Text(value),
-              );
-            }).toList(),
-          ),
-        ],
+              ),
+            );
+          }).toList(),
+        ),
       ),
     );
   }

--- a/frontend/lib/widgets/select_box.dart
+++ b/frontend/lib/widgets/select_box.dart
@@ -1,0 +1,58 @@
+import 'package:find_toilet/utilities/style.dart';
+import 'package:flutter/material.dart';
+
+class SelectBox extends StatefulWidget {
+  final List<String> selectList;
+  final double width, height;
+  const SelectBox(
+      {super.key,
+      required this.selectList,
+      required this.width,
+      required this.height});
+
+  @override
+  State<SelectBox> createState() => _SelectBox();
+}
+
+class _SelectBox extends State<SelectBox> {
+  late String dropdownValue;
+  @override
+  void initState() {
+    super.initState();
+    dropdownValue = widget.selectList.first;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: widget.width,
+      height: widget.height,
+      decoration: BoxDecoration(
+          color: whiteColor, borderRadius: BorderRadius.circular(5)),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          DropdownButton<String>(
+            itemHeight: 50,
+            value: dropdownValue,
+            icon: const Icon(Icons.arrow_drop_down),
+            elevation: 16,
+            style: const TextStyle(color: Colors.black),
+            onChanged: (String? value) {
+              setState(() {
+                dropdownValue = value!;
+              });
+            },
+            items:
+                widget.selectList.map<DropdownMenuItem<String>>((String value) {
+              return DropdownMenuItem<String>(
+                value: value,
+                child: Text(value),
+              );
+            }).toList(),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/lib/widgets/text_widget.dart
+++ b/frontend/lib/widgets/text_widget.dart
@@ -44,13 +44,8 @@ class TextWithIcon extends StatelessWidget {
   Widget build(BuildContext context) {
     return Row(
       children: [
-        Icon(
-          icon,
-          color: convertedColor(iconColor),
-        ),
-        const SizedBox(
-          width: 10,
-        ),
+        Icon(icon, color: convertedColor(iconColor)),
+        const SizedBox(width: 10),
         CustomText(
           title: text,
           fontSize: fontSize,

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -115,6 +115,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
+  modal_bottom_sheet:
+    dependency: "direct main"
+    description:
+      name: modal_bottom_sheet
+      sha256: ef533916a2c3089571c32bd34e410faca77a6849a3f28f748e0794525c5658a0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
   path:
     dependency: transitive
     description:
@@ -186,3 +194,4 @@ packages:
     version: "2.1.4"
 sdks:
   dart: ">=2.19.0 <4.0.0"
+  flutter: ">=3.0.0"

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+  modal_bottom_sheet: ^2.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
---
title: "[FE/BE] feat : "
---

> 제목은 `[FE/BE] 종류 : 기능`으로 작성해주세요. <br>
```
 feat : 새로운 기능에 대한 커밋
 fix : build 빌드 관련 파일 수정에 대한 커밋
 build : 빌드 관련 파일 수정에 대한 커밋
 chore : 그 외 자잘한 수정에 대한 커밋
 docs : 문서 수정에 대한 커밋
 style : 코드 스타일 혹은 포맷 등에 관한 커밋
 refactor : 코드 리팩토링에 대한 커밋
 test : 테스트 코드 수정에 대한 커밋
 ci : CI 관련 설정 수정에 대한 커밋
```
> 라벨은 FE, BE 중 하나를 선택해주세요 <br><br>
> reviewer를 지정해주세요.

<br>

## 관련 이슈
- closes #14 

<br>

## PR 생성 전 확인 사항
- [x]  Warning Message가 발생하지 않았나요?
- [x]  Coding Convention을 준수했나요?
- [x]  Conflict를 해결했나요?

<br>

## 작업 내용
![검색 결과 화면](https://user-images.githubusercontent.com/97578485/220856430-3caefbc4-d770-4f84-bb2f-9e6497561a3c.png)
![하단 시트 펼침](https://user-images.githubusercontent.com/97578485/220858273-f16de73c-c1f6-45c6-912b-55058cd5ed0b.png)
![내비게이션 모달](https://user-images.githubusercontent.com/97578485/220857586-46597e14-9d49-4d2c-aa8e-29529cc2dfc6.png)

- 검색 바에 검색창, 햄버거 버튼, 즐겨찾기 버튼, 메인페이지 이동 버튼 존재
- 검색 바 아래에 필터 존재
- 검색 결과로 정렬 선택 상자
- 화장실 목록 출력
- 화장실별로 좋아요, 길찾기 버튼 존재
- 좋아요 버튼 터치 시, 아이콘 변경
- 길찾기 버튼 터치 시, 내비게이션 앱 선택 모달 나타남
- 검색 결과 시트를 위로 올리면 길이가 길어짐 (화장실 목록이 여러 개 뜸)

<br>

## PR 특이 사항
- 메인 화면도 검색 결과 화면과 비슷함
- 지도가 들어갈 부분에 임시로 표시해둠
- 검색 결과 스크롤 미적용 (-> 하단 줄무늬 표시)
- 좋아요 버튼 터치 시, 즐겨찾기 폴더 선택 모달 미적용
- 추후 선택 상자 커스터마이징
- 검색 기능 미완료
- 내비게이션 앱 선택 모달 수정
