### PR TITLE
#38 [BE-윤주] chore: 데이터 최대 개수 150개로 제한

### DIFF
--- a/backend/src/main/java/com/Fourilet/project/fourilet/data/repository/ToiletRepositoryImpl.java
+++ b/backend/src/main/java/com/Fourilet/project/fourilet/data/repository/ToiletRepositoryImpl.java
@@ -34,6 +34,9 @@ public class ToiletRepositoryImpl implements ToiletRepositoryCustom{
 
     @Override
     public Page<ToiletDto> nearByToilet(ToiletGetCondition condition, Pageable pageable){
+        int maxPageSize = 150;
+        int requestedPageSize = pageable.getPageSize();
+        int effectivePageSize = Math.min(maxPageSize, requestedPageSize);
         QueryResults<ToiletDto> result = queryFactory.select(
                         new QToiletDto(
                                 toilet.toiletId,
@@ -84,17 +87,20 @@ public class ToiletRepositoryImpl implements ToiletRepositoryCustom{
                                 toilet.lat
                         )).asc())
                 .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
+                .limit(effectivePageSize)
                 .fetchResults();
 
         List<ToiletDto> content = result.getResults();
-        long total = result.getTotal();
+        long total = Math.min(result.getTotal(), maxPageSize);
 
         return new PageImpl<>(content, pageable, total);
     }
 
     @Override
     public Page<ToiletDto> searchToiletDistance(ToiletSearchCondition condition, Pageable pageable){
+        int maxPageSize = 150;
+        int requestedPageSize = pageable.getPageSize();
+        int effectivePageSize = Math.min(maxPageSize, requestedPageSize);
         QueryResults<ToiletDto> result = queryFactory.select(
                         new QToiletDto(
                                 toilet.toiletId,
@@ -139,17 +145,20 @@ public class ToiletRepositoryImpl implements ToiletRepositoryCustom{
                         )).asc()
                 )
                 .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
+                .limit(effectivePageSize)
                 .fetchResults();
 
         List<ToiletDto> content = result.getResults();
-        long total = result.getTotal();
+        long total = Math.min(result.getTotal(), maxPageSize);
 
         return new PageImpl<>(content, pageable, total);
     }
 
     @Override
     public Page<ToiletDto> searchToiletScore(ToiletSearchCondition condition, Pageable pageable){
+        int maxPageSize = 150;
+        int requestedPageSize = pageable.getPageSize();
+        int effectivePageSize = Math.min(maxPageSize, requestedPageSize);
         QueryResults<ToiletDto> result = queryFactory.select(
                         new QToiletDto(
                                 toilet.toiletId,
@@ -186,17 +195,20 @@ public class ToiletRepositoryImpl implements ToiletRepositoryCustom{
                         review.score.coalesce((float)0).avg().desc(), review.count().desc()
                 )
                 .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
+                .limit(effectivePageSize)
                 .fetchResults();
 
         List<ToiletDto> content = result.getResults();
-        long total = result.getTotal();
+        long total = Math.min(result.getTotal(), maxPageSize);
 
         return new PageImpl<>(content, pageable, total);
     }
 
     @Override
     public Page<ToiletDto> searchToiletComment(ToiletSearchCondition condition, Pageable pageable){
+        int maxPageSize = 150;
+        int requestedPageSize = pageable.getPageSize();
+        int effectivePageSize = Math.min(maxPageSize, requestedPageSize);
         QueryResults<ToiletDto> result = queryFactory.select(
                         new QToiletDto(
                                 toilet.toiletId,
@@ -233,11 +245,11 @@ public class ToiletRepositoryImpl implements ToiletRepositoryCustom{
                         review.count().desc(), review.score.coalesce((float)0).avg().desc()
                 )
                 .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
+                .limit(effectivePageSize)
                 .fetchResults();
 
         List<ToiletDto> content = result.getResults();
-        long total = result.getTotal();
+        long total = Math.min(result.getTotal(), maxPageSize);
 
         return new PageImpl<>(content, pageable, total);
     }


### PR DESCRIPTION
---
title: "[BE] chore : 데이터 최대 개수 150개로 제한"
---

<br>

## 관련 이슈
- closes #38

<br>

## PR 생성 전 확인 사항
- [ ]  Warning Message가 발생하지 않았나요?
- [ ]  Coding Convention을 준수했나요?
- [ ]  Conflict를 해결했나요?

<br>

## 작업 내용
- 프론트엔드의 요청에 맞게 화장실 API 반환 데이터의 최대 개수를 150개로 제한했습니다.
-

<br>

## PR 특이 사항
-
-
