### PR TITLE
#38 [BE-윤주] chore: 액세스 토큰이 유효하지 않은 경우 상태 코드 변경

### DIFF
--- a/backend/src/main/java/com/Fourilet/project/fourilet/config/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/backend/src/main/java/com/Fourilet/project/fourilet/config/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -146,8 +146,6 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
         String requestURI = request.getRequestURI();
         String token = jwtService.extractAccessToken(request).orElse(null);
 
-        System.out.println("flag "+flag);
-
         if((requestURI.matches(".*/toilet/.*") && token != null) || !requestURI.matches(".*/toilet/.*")){
             try {
                 String email = JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token).getClaim("email").asString();
@@ -172,7 +170,7 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
                 return;
             } catch (JWTVerificationException e) {
                 // 액세스 토큰이 유효하지 않은 경우
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.setStatus(HttpServletResponse.SC_FORBIDDEN);
                 response.setContentType("application/json");
                 response.setCharacterEncoding("UTF-8");
                 String message = "{\"message\": \"유효하지 않은 액세스 토큰\"}";


### PR DESCRIPTION
---
title: "[BE] chore: 액세스 토큰이 유효하지 않은 경우 상태 코드 변경"
---

<br>

## 관련 이슈
- closes #38

<br>

## PR 생성 전 확인 사항
- [ ]  Warning Message가 발생하지 않았나요?
- [ ]  Coding Convention을 준수했나요?
- [ ]  Conflict를 해결했나요?

<br>

## 작업 내용
- 프론트의 요청으로 액세스 토큰이 유효하지 않은 경우의 상태 코드를 401에서 403으로 변경했습니다.
-

<br>

## PR 특이 사항
-
-
